### PR TITLE
Ignore stale messages

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1405,6 +1405,8 @@ func (portal *Portal) HandleTextMessage(source *User, message whatsapp.TextMessa
 	if message.Info.Timestamp+MaximumMsgLagActivity < uint64(time.Now().Unix()) {
 		sender.UpdateActivityTs(message.Info.Timestamp)
 		portal.bridge.UpdateActivePuppetCount()
+	} else {
+		portal.log.Debugfln("Did not update acitivty for %s, ts %d was too stale", message.Info.SenderJid, message.Info.Timestamp)
 	}
 	return true
 }

--- a/portal.go
+++ b/portal.go
@@ -1402,7 +1402,7 @@ func (portal *Portal) HandleTextMessage(source *User, message whatsapp.TextMessa
 		portal.finishHandling(source, message.Info.Source, resp.EventID)
 	}
 	sender := portal.bridge.GetPuppetByJID(message.Info.SenderJid)
-	if message.Info.Timestamp+MaximumMsgLagActivity < uint64(time.Now().Unix()) {
+	if message.Info.Timestamp+MaximumMsgLagActivity > uint64(time.Now().Unix()) {
 		sender.UpdateActivityTs(message.Info.Timestamp)
 		portal.bridge.UpdateActivePuppetCount()
 	} else {


### PR DESCRIPTION
Any message older than 5 minutes we treat as "inactive" and do not count against a user's activity. This means backfill (other than very recent backfill) won't be counted as activity. This should also mean any reconnections / really-late messages will also go for free, but I think it's an acceptable tradeoff.