### PR TITLE
Check the participant if the JID is empty

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1425,10 +1425,11 @@ func (portal *Portal) HandleTextMessage(source *User, message whatsapp.TextMessa
 
 	var sender *Puppet
 	if message.Info.FromMe {
+		// Ignore tracking activity for our own users
 		sender = nil
 	} else if len(message.Info.SenderJid) != 0 {
 		sender = portal.bridge.GetPuppetByJID(message.Info.SenderJid)
-		// As seen in https://github.com/vector-im/mautrix-whatsapp/commit/210b1caf655420ae31174ac3fc6eab2ab182749e
+		// As seen in https://github.com/vector-im/mautrix-whatsapp/blob/210b1caf655420ae31174ac3fc6eab2ab182749e/portal.go#L271-L282
 	} else if len(message.Info.Source.GetParticipant()) != 0 {
 		sender = portal.bridge.GetPuppetByJID(message.Info.Source.GetParticipant())
 	}


### PR DESCRIPTION
In some cases we appeared to add `nil` puppets to the DB, I've attempted to fix this here.