### PR TITLE
Avoid logging message contents on WARN loglevel

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -458,7 +458,7 @@ func (portal *Portal) handleMessage(source *User, evt *events.Message) {
 			existingMsg.UpdateMXID("net.maunium.whatsapp.fake::"+existingMsg.MXID, false)
 		}
 	} else {
-		portal.log.Warnfln("Unhandled message: %+v / %+v", evt.Info, evt.Message)
+		portal.log.Warnfln("Unhandled message: %+v", evt.Info)
 		if existingMsg != nil {
 			_, _ = portal.MainIntent().RedactEvent(portal.MXID, existingMsg.MXID, mautrix.ReqRedact{
 				Reason: "The undecryptable message contained an unsupported message type",


### PR DESCRIPTION
Observed in the wild for a `highlyStructuredMessage`